### PR TITLE
fix: remove sonarcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,20 +73,3 @@ jobs:
           MONGO_URI: 'mongodb://localhost:27017/musica'
           STORAGE_DEST: '/tmp/musica'
           PORT_API: 3000
-
-  code-analysis:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: 'Checkout code'
-        uses: actions/checkout@v3
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.organization=mrdn
-            -Dsonar.projectKey=musica
-        env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
### Description

Remove sonarcloud from CI workflow, it's already operating as third-party API while making pull request.